### PR TITLE
Migrate legacy app token to app JWT

### DIFF
--- a/src/Gopay/GopayClient.php
+++ b/src/Gopay/GopayClient.php
@@ -45,7 +45,6 @@ class GopayClient {
         $this->storeAppJWT = $storeAppJWT;
         $this->merchantAppJWT = $merchantAppJWT;
         $this->requester = new HttpRequester();
-
     }
 
     public function getStoreBasedContext() {
@@ -84,7 +83,7 @@ class GopayClient {
     }
 
     public function getStore($id) {
-        $context = $this->getStoreBasedContext()->withPath("stores/" . $id);
+        $context = $this->getStoreBasedContext()->withPath(array("stores", $id));
         return RequesterUtils::execute_get(Store::class, $context);
     }
 
@@ -156,8 +155,12 @@ class GopayClient {
             "email" => $email,
             "data" => $data
         );
-        $response = $context->getRequester()->post($context->getFullURL(), $payload, RequesterUtils::getHeaders($context));
-        return TransactionToken::getCardSchema()->parse($response, array($context));
+        return RequesterUtils::execute_post(TransactionToken::class, $context, $payload);
+    }
+
+    public function getTransactionToken($storeId, $transactionTokenId) {
+        $context = $this->getStoreBasedContext()->withPath(array("stores", $storeId, "tokens", $transactionTokenId));
+        return RequesterUtils::execute_get(TransactionToken::class, $context);
     }
 
     public function createCharge($transactionTokenId,

--- a/src/Gopay/Requests/RequestContext.php
+++ b/src/Gopay/Requests/RequestContext.php
@@ -2,22 +2,20 @@
 
 namespace Gopay\Requests;
 
+use Gopay\Resources\AppJWT;
+
 class RequestContext
 {
     private $path;
     private $endpoint;
-    private $appToken;
-    private $appSecret;
+    private $appJWT;
     private $requester;
 
-
-
-    public function __construct($requester, $endpoint, $path, $appToken, $appSecret) {
+    public function __construct($requester, $endpoint, $path, AppJWT $appJWT) {
         $this->requester = $requester;
         $this->path = $path;
         $this->endpoint = $endpoint;
-        $this->appToken = $appToken;
-        $this->appSecret = $appSecret;
+        $this->appJWT = $appJWT;
     }
 
     public function getRequester()
@@ -25,13 +23,13 @@ class RequestContext
         return $this->requester;
     }
 
-    public function withAppToken($appToken, $appSecret) {
-        return new RequestContext($this->requester, $this->endpoint, $this->path, $appToken, $appSecret);
+    public function withAppToken($appJWT): self {
+        return new RequestContext($this->requester, $this->endpoint, $this->path, $appJWT);
     }
 
-    public function withPath($path) {
+    public function withPath($path): self {
         $newPath = is_array($path) ? join("/", $path) : $path;
-        return new RequestContext($this->requester, $this->endpoint, $newPath, $this->appToken, $this->appSecret);
+        return new RequestContext($this->requester, $this->endpoint, $newPath, $this->appJWT);
     }
 
     public function appendPath($path) {
@@ -45,13 +43,14 @@ class RequestContext
     }
 
     public function getAuthorizationHeaders() {
-        if ($this->appToken == NULL) {
+        if ($this->appJWT == NULL) {
             return array();
         } else {
-            $key = $this->appToken;
-            $secretText = $this->appSecret ? "|" . $this->appSecret : "";
+            $key = $this->appJWT->token;
+            $secret = $this->appJWT->secret;
+            $secretText = $secret ? $secret . "." : "";
             return array(
-                "Authorization" => "ApplicationToken $key$secretText"
+                "Authorization" => "Bearer $secretText$key"
             );
         }
     }

--- a/src/Gopay/Resources/AppJWT.php
+++ b/src/Gopay/Resources/AppJWT.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Gopay\Resources;
+
+use Gopay\Resources\StoreAppJWT;
+use Gopay\Resources\MerchantAppJWT;
+use Gopay\Utility\Json\JsonSchema;
+
+abstract class AppJWT {
+    public $token;
+    public $secret;
+
+    protected function __construct($token, $secret) {
+        $this->token = $token;
+        $this->secret = $secret;
+    }
+
+    public static function createToken($appToken, $appSecret): AppJWT {
+        $tokenBody = base64_decode(explode(".", $appToken)[1]);
+        $appTokenBody = json_decode($tokenBody, true);
+        if (array_key_exists("store_id", $appTokenBody)) {
+            $class = StoreAppJWT::class;
+        } else {
+            $class = MerchantAppJWT::class;
+        }
+        $result = $class::getSchema()->parse($appTokenBody, array($appToken, $appSecret));
+        return $result;
+    }
+}
+
+class StoreAppJWT extends AppJWT {
+    use Jsonable;
+
+    public $sub;
+    public $iat;
+    public $merchantId;
+    public $storeId;
+    public $domains;
+    public $mode;
+    public $creatorId;
+    public $version;
+    public $jti;
+
+    public function __construct($sub, $iat, $merchantId, $storeId, $domains, $mode, $creatorId, $version, $jti, $token, $secret) {
+        if ($sub != "app_token") {
+            throw new Exception("Invalid JWT");
+        }
+        parent::__construct($token, $secret);
+        $this->iat = $iat;
+        $this->merchantId = $merchantId;
+        $this->storeId = $storeId;
+        $this->domains = $domains;
+        $this->mode = $mode;
+        $this->creatorId = $creatorId;
+        $this->version = $version;
+        $this->jti = $jti;
+    }
+
+    protected static function initSchema() {
+        return JsonSchema::fromClass(StoreAppJWT::class, true, false);
+    }
+}
+
+class MerchantAppJWT extends AppJWT {
+    use Jsonable;
+
+    public $sub;
+    public $issuedAt;
+    public $merchantId;
+    public $creatorId;
+    public $version;
+    public $jti;
+
+    public function __construct($sub, $iat, $merchantId, $creatorId, $version, $jti, $token, $secret) {
+        if ($sub != "app_token") {
+            throw new Exception("Invalid JWT");
+        }
+        parent::__construct($token, $secret);
+        $this->iat = $iat;
+        $this->merchantId = $merchantId;
+        $this->creatorId = $creatorId;
+        $this->version = $version;
+        $this->jti = $jti;
+    }
+
+    protected static function initSchema() {
+        return JsonSchema::fromClass(MerchantAppJWT::class, true, false);
+    }
+}

--- a/src/Gopay/Resources/TransactionToken.php
+++ b/src/Gopay/Resources/TransactionToken.php
@@ -9,8 +9,6 @@ use Gopay\Utility\RequesterUtils;
 class TransactionToken extends Resource {
     use Jsonable;
 
-    private static $cardDataSchema;
-
     public $storeId;
     public $email;
     public $paymentType;
@@ -45,18 +43,9 @@ class TransactionToken extends Resource {
         $this->data = $data;
     }
 
-    protected static function initSchema()
-    {
-        return JsonSchema::fromClass(TransactionToken::class);
-    }
-
-
-    public static function getCardSchema() {
-        if (!isset(self::$cardDataSchema)) {
-            self::$cardDataSchema = JsonSchema::fromClass(self::class)
-                ->upsert("data", true, $formatter = CardData::getSchema()->getParser());
-        }
-        return self::$cardDataSchema;
+    protected static function initSchema() {
+        return JsonSchema::fromClass(self::class)
+            ->upsert("data", true, $formatter = CardData::getSchema()->getParser());
     }
 
     public function createCharge($amount, $currency, $capture = true, $metadata = NULL) {

--- a/src/Gopay/Utility/FunctionalUtils.php
+++ b/src/Gopay/Utility/FunctionalUtils.php
@@ -34,14 +34,15 @@ abstract class FunctionalUtils {
         return null;
     }
 
-    public static function get_class_vars_assoc($called) {
-        //echo "called: $called \n";
+    public static function get_class_vars_assoc($called, $includeParentVars) {
+        // echo "called: $called \n";
         $classVars = array_keys(get_class_vars($called));
 
         $parent = get_parent_class($called);
-        while ( $parent !== FALSE ) {
+        while ($parent !== FALSE) {
             $parentVars = array_keys(get_class_vars($parent));
-            $classVars = array_merge($parentVars, array_diff($classVars, $parentVars));
+            $classVars = array_diff($classVars, $parentVars);
+            $classVars = $includeParentVars ? array_merge($parentVars, $classVars) : $classVars;
             $parent = get_parent_class($parent);
         }
 

--- a/src/Gopay/Utility/Json/JsonSchema.php
+++ b/src/Gopay/Utility/Json/JsonSchema.php
@@ -76,8 +76,8 @@ class JsonSchema {
         };
     }
 
-    public static function fromClass($targetClass, $snakeCase = true) {
-        $classVars = FunctionalUtils::get_class_vars_assoc($targetClass);
+    public static function fromClass($targetClass, $snakeCase = true, $includeParentVars = true) {
+        $classVars = FunctionalUtils::get_class_vars_assoc($targetClass, $includeParentVars);
         $newSchema = new JsonSchema($targetClass);
         return array_reduce(
             $classVars, function ($schema, $path) use ($snakeCase) {

--- a/tests/Gopay/Integration/BankAccountsTest.php
+++ b/tests/Gopay/Integration/BankAccountsTest.php
@@ -29,7 +29,7 @@ class BankAccountsTest extends TestCase
 EOD;
 
         $json = json_decode($str, $assoc = true);
-        $bankAccount = BankAccount::getSchema()->parse($json, array($this->getClient()->getDefaultContext()));
+        $bankAccount = BankAccount::getSchema()->parse($json, array($this->getClient()->getStoreBasedContext()));
         $this->assertEquals("11111111-1111-1111-1111-111111111111", $bankAccount->id);
         $this->assertEquals("Test holder", $bankAccount->holderName);
         $this->assertEquals("Test bank", $bankAccount->bankName);
@@ -87,7 +87,7 @@ EOD;
         }
 EOD;
         $json = json_decode($str, true);
-        $bankAccounts = Paginated::fromResponse($json, array(), BankAccount::class, $this->getClient()->getDefaultContext());
+        $bankAccounts = Paginated::fromResponse($json, array(), BankAccount::class, $this->getClient()->getStoreBasedContext());
         $this->assertEquals(false, $bankAccounts->hasMore);
         $this->assertEquals(2, count($bankAccounts->items));
         $this->assertEquals("Holder 2", $bankAccounts->items[1]->holderName);

--- a/tests/Gopay/Integration/IntegrationSuite.php
+++ b/tests/Gopay/Integration/IntegrationSuite.php
@@ -7,13 +7,15 @@ use Gopay\Resources\AppJWT;
 trait IntegrationSuite
 {
     public $client = NULL;
+    public $storeAppJWT;
 
     private function init()
     {
         $token = getenv('GOPAY_PHP_TEST_TOKEN');
         $secret = getenv('GOPAY_PHP_TEST_SECRET');
         $endpoint = getenv('GOPAY_PHP_TEST_ENDPOINT');
-        $this->client = new GopayClient(AppJWT::createToken($token, $secret), null, $endpoint);
+        $this->storeAppJWT = AppJWT::createToken($token, $secret);
+        $this->client = new GopayClient($this->storeAppJWT, null, $endpoint);
     }
 
     public function getClient() {

--- a/tests/Gopay/Integration/IntegrationSuite.php
+++ b/tests/Gopay/Integration/IntegrationSuite.php
@@ -2,6 +2,7 @@
 namespace GopayTest\Integration;
 
 use Gopay\GopayClient;
+use Gopay\Resources\AppJWT;
 
 trait IntegrationSuite
 {
@@ -12,7 +13,7 @@ trait IntegrationSuite
         $token = getenv('GOPAY_PHP_TEST_TOKEN');
         $secret = getenv('GOPAY_PHP_TEST_SECRET');
         $endpoint = getenv('GOPAY_PHP_TEST_ENDPOINT');
-        $this->client = new GopayClient($token, $secret, $endpoint);
+        $this->client = new GopayClient($endpoint, AppJWT::createToken($token, $secret));
     }
 
     public function getClient() {
@@ -21,6 +22,4 @@ trait IntegrationSuite
         }
         return $this->client;
     }
-
-
 }

--- a/tests/Gopay/Integration/IntegrationSuite.php
+++ b/tests/Gopay/Integration/IntegrationSuite.php
@@ -13,7 +13,7 @@ trait IntegrationSuite
         $token = getenv('GOPAY_PHP_TEST_TOKEN');
         $secret = getenv('GOPAY_PHP_TEST_SECRET');
         $endpoint = getenv('GOPAY_PHP_TEST_ENDPOINT');
-        $this->client = new GopayClient($endpoint, AppJWT::createToken($token, $secret));
+        $this->client = new GopayClient(AppJWT::createToken($token, $secret), null, $endpoint);
     }
 
     public function getClient() {

--- a/tests/Gopay/Integration/LedgerTest.php
+++ b/tests/Gopay/Integration/LedgerTest.php
@@ -29,7 +29,7 @@ class LedgerTest extends TestCase
 EOD;
 
         $json = json_decode($str, true);
-        $ledger = Ledger::getSchema()->parse($json, array($this->getClient()->getDefaultContext()));
+        $ledger = Ledger::getSchema()->parse($json, array($this->getClient()->getStoreBasedContext()));
         $this->assertEquals("11111111-1111-1111-1111-111111111111", $ledger->id);
         $this->assertEquals("22222222-2222-2222-2222-222222222222", $ledger->storeId);
         $this->assertEquals(1200, $ledger->amount);

--- a/tests/Gopay/Integration/StoreTest.php
+++ b/tests/Gopay/Integration/StoreTest.php
@@ -65,7 +65,7 @@ class StoreTest extends TestCase
         }
 EOD;
         $json = json_decode($str, true);
-        $store = Store::getSchema()->parse($json, array($this->getClient()->getDefaultContext()));
+        $store = Store::getSchema()->parse($json, array($this->getClient()->getStoreBasedContext()));
         $this->assertEquals("Store 1", $store->name);
         $this->assertEquals("11111111-1111-1111-1111-111111111111", $store->id);
         $this->assertEquals("2017-03-21T01:32:13.702689Z", $store->createdOn);
@@ -101,7 +101,7 @@ EOD;
         }
 EOD;
         $json = json_decode($str, true);
-        $stores = Paginated::fromResponse($json, array(), Store::class, $this->getClient()->getDefaultContext());
+        $stores = Paginated::fromResponse($json, array(), Store::class, $this->getClient()->getStoreBasedContext());
         $this->assertEquals(false, $stores->hasMore);
         $this->assertEquals(2, count($stores->items));
         $this->assertEquals("Store 2", $stores->items[1]->name);

--- a/tests/Gopay/Integration/SubscriptionTest.php
+++ b/tests/Gopay/Integration/SubscriptionTest.php
@@ -27,7 +27,7 @@ class SubscriptionTest extends TestCase
 EOD;
 
         $json = json_decode($str, true);
-        $subscription = Subscription::getSchema()->parse($json, array($this->getClient()->getDefaultContext()));
+        $subscription = Subscription::getSchema()->parse($json, array($this->getClient()->getStoreBasedContext()));
         $this->assertEquals(1000, $subscription->amount);
         $this->assertEquals("11111111-1111-1111-1111-111111111111", $subscription->id);
         $this->assertEquals("22222222-2222-2222-2222-222222222222", $subscription->storeId);

--- a/tests/Gopay/Integration/TransactionTest.php
+++ b/tests/Gopay/Integration/TransactionTest.php
@@ -35,7 +35,7 @@ class TransactionTest extends TestCase
 EOD;
 
         $json = json_decode($str, true);
-        $transactions = Paginated::fromResponse($json, array(), Transaction::class, $this->getClient()->getDefaultContext());
+        $transactions = Paginated::fromResponse($json, array(), Transaction::class, $this->getClient()->getStoreBasedContext());
         $this->assertEquals(false, $transactions->hasMore);
         $this->assertEquals(1, count($transactions->items));
         $item = $transactions->items[0];

--- a/tests/Gopay/Integration/TransactionTokenTest.php
+++ b/tests/Gopay/Integration/TransactionTokenTest.php
@@ -9,11 +9,16 @@ class TransactionTokenTest extends TestCase
     use IntegrationSuite;
     use Requests;
 
-    public function testCreateToken()
-    {
+    public function testCreateToken() {
         $transactionToken = $this->createValidToken();
         $this->assertEquals("test@test.com", $transactionToken->email);
         $this->assertEquals("one_time", $transactionToken->type);
+    }
+
+    public function testGetExistingToken() {
+        $transactionToken = $this->createValidToken();
+        $retrievedTransactionToken = $this->getClient()->getTransactionToken($this->storeAppJWT->storeId, $transactionToken->id);
+        $this->assertEquals($transactionToken->id, $retrievedTransactionToken->id);
     }
 
     public function testInvalidCardNumber() {

--- a/tests/Gopay/Integration/TransferTest.php
+++ b/tests/Gopay/Integration/TransferTest.php
@@ -30,7 +30,7 @@ class TransferTest extends TestCase
 EOD;
 
         $json = json_decode($str, true);
-        $transfer = Transfer::getSchema()->parse($json, array($this->getClient()->getDefaultContext()));
+        $transfer = Transfer::getSchema()->parse($json, array($this->getClient()->getStoreBasedContext()));
         $this->assertEquals("11111111-1111-1111-1111-11111111111", $transfer->id);
         $this->assertEquals("22222222-2222-2222-2222-222222222222", $transfer->bankAccountId);
         $this->assertEquals(0, $transfer->amount);


### PR DESCRIPTION
Implemented both store app JWT and merchant app JWT. Currently no routes utilises the merchant app JWT.

Added route to retrieve transaction token info and cleaned up schema

Phpunit passes.